### PR TITLE
add viewName property

### DIFF
--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -41,7 +41,7 @@ export default Ember.Component.extend(InvokeActionMixin, {
     'timezone', 'now',
 
     // views
-    'views', 'defaultView',
+    'views',
 
     // agenda options
     'allDaySlot', 'allDayText', 'slotDuration', 'slotLabelFormat', 'slotLabelInterval', 'snapDuration', 'scrollTime',
@@ -152,6 +152,11 @@ export default Ember.Component.extend(InvokeActionMixin, {
       }
     });
 
+    //manual options
+    if (this.get('viewName') !== undefined) {
+      options['defaultView'] = this.get('viewName');
+    }
+
     return options;
   }),
 
@@ -184,6 +189,14 @@ export default Ember.Component.extend(InvokeActionMixin, {
     });
 
     return actions;
+  }),
+
+  /////////////////////////////////////
+  // OBSERVERS
+  /////////////////////////////////////
+  viewNameDidChange: Ember.observer('viewName', function() {
+    let viewName = this.get('viewName');
+    this.$().fullCalendar('changeView', viewName);
   })
 
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  viewName: 'agendaWeek',
+  actions: {
+    changeView(viewName) {
+      this.set('viewName', viewName);
+    }
+  }
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,7 @@
 <h2 id="title">Welcome to Ember</h2>
 
-{{outlet}}
+<button onclick={{action "changeView" "month"}}>Month</button>
+<button onclick={{action "changeView" "agendaWeek"}}>Week</button>
+<button onclick={{action "changeView" "agendaDay"}}>Day</button>
+
+{{full-calendar viewName=viewName}}


### PR DESCRIPTION
We do DDAU in Ember.
So, to change calendar view modes, we should have a `viewName` property and have the component change accordingly.

We have to do it via an observer. We can create these observers automatically in the future, if we ever find a pattern in them.

Also, `defaultView` can't be automatically inserted in options. It should assume the value of `viewName` initially.