### PR TITLE
rename actions computed property

### DIFF
--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -123,7 +123,7 @@ export default Ember.Component.extend(InvokeActionMixin, {
     let options =
       Object.assign(
         this.get('options'),
-        this.get('actions')
+        this.get('hooks')
       );
 
     // add the license key for the scheduler
@@ -170,7 +170,7 @@ export default Ember.Component.extend(InvokeActionMixin, {
    * Returns an object that contains a function for each action passed
    * into the component. This object is passed into Fullcalendar.
    */
-  actions: Ember.computed(function() {
+  hooks: Ember.computed(function() {
     let actions = {};
 
     this.get('usedEvents').forEach((eventName) => {


### PR DESCRIPTION
this will make the addon compatible with Ember 1.13.11 (and possibly lower)