### PR TITLE
Pass this.$() to actions

### DIFF
--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -178,7 +178,7 @@ export default Ember.Component.extend(InvokeActionMixin, {
       // create an event handler that runs the function inside an event loop.
       actions[eventName] = (...args) => {
         Ember.run.schedule('actions', this, () => {
-          this.invokeAction(eventName, ...args);
+          this.invokeAction(eventName, ...args, this.$());
         });
       };
     });


### PR DESCRIPTION
This lets us invoke methods on our actions.
Good example:
```js
actions: {
  select(start, end, jsEvent, view, el) {
    //do your stuff with start and end, probably create an event
    el.fullCalendar('unselect');
  }
}
```