### PR TITLE
Passing on eventLimitClick to fullCalendar

### DIFF
--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -65,6 +65,7 @@ export default Ember.Component.extend(InvokeActionMixin, {
 
     // event rendering
     'eventColor', 'eventBackgroundColor', 'eventBorderColor', 'eventTextColor', 'nextDayThreshold', 'eventOrder',
+    'eventLimitClick',
 
     // event dragging & resizing
     'editable', 'eventStartEditable', 'eventDurationEditable', 'dragRevertDuration', 'dragOpacity', 'dragScroll',


### PR DESCRIPTION
Needed http://fullcalendar.io/docs/display/eventLimitClick/ to be included in the options.