### PR TITLE
Improve installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To install it run:
 ## Overview
 This addon currently supports every option and callback currently available for FullCalendar 2.0. Please see the [FullCalendar documentation](http://fullcalendar.io/docs/) for more information.
 
-*NOTE:* This addon installs both FullCalendar and the new FullCalendar Scheduler addon. While you aren't required to use the Scheduler, it is currently packaged. In the future, there may be an option to disable importing the Scheduler if it's not needed.
+*NOTE:* By default, this addon installs and imports both FullCalendar and the FullCalendar Scheduler addon. You may opt out of importing the FullCalendar Scheduler addon if it's not needed.
 
 ## Usage
 
@@ -102,11 +102,30 @@ export default Ember.Controller.extend({
 });
 ```
 
-## FullCalendar Scheduler License
+## FullCalendar Scheduler
+
+### Opting out
+By default, the FullCalendar Scheduler addon is imported. To opt out, add the following to your application's `ember-cli-build.js`:
+```javascript
+  var app = new EmberApp(defaults, {
+    emberFullCalendar: {
+      scheduler: false
+    }
+    // Other options here, as needed.
+  });
+```
+
+### License
 By default, the addon uses the [Free Trial License Key](http://fullcalendar.io/scheduler/download/) provided by FullCalendar. If you have a paid license key, you may set it by explicitly passing it into the component as `schedulerLicenseKey` or, the better option, is to set it in your `config/environment.js` file like so:
 
 ```javascript
 	emberFullCalendar: {
 		schedulerLicenseKey: '<your license key>'
 	}
+```
+
+### Moment
+While not required by `ember-fullcalendar`, you may find it helpful to be able to import moment via ES6. Install [`ember-cli-moment-shims`](https://www.npmjs.com/package/ember-cli-moment-shim) to enable:
+```javascript
+import moment from 'moment';
 ```

--- a/blueprints/ember-fullcalendar/index.js
+++ b/blueprints/ember-fullcalendar/index.js
@@ -2,8 +2,8 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function() {
-    return addBowerPackageToProject('fullcalendar', '^2.7.3').then(function () {
-      return addBowerPackageToProject('fullcalendar-scheduler', '^1.3.2');
+    return this.addBowerPackageToProject('fullcalendar', '^2.7.3').then(function () {
+      return this.addBowerPackageToProject('fullcalendar-scheduler', '^1.3.2');
     });
   }
 };

--- a/blueprints/ember-fullcalendar/index.js
+++ b/blueprints/ember-fullcalendar/index.js
@@ -2,7 +2,7 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('fullcalendar', '^2.7.3').then(function () {
+    return this.addBowerPackageToProject('fullcalendar', '^2.7.3').then(() => {
       return this.addBowerPackageToProject('fullcalendar-scheduler', '^1.3.2');
     });
   }

--- a/blueprints/ember-fullcalendar/index.js
+++ b/blueprints/ember-fullcalendar/index.js
@@ -2,10 +2,8 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('fullcalendar').then(() => {
-      return this.addBowerPackageToProject('fullcalendar-scheduler').then(() => {
-        return this.addAddonToProject('ember-cli-moment-shim', '0.6.2');
-      });
+    return addBowerPackageToProject('fullcalendar', '^2.7.3').then(function () {
+      return addBowerPackageToProject('fullcalendar-scheduler', '^1.3.2');
     });
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,8 @@
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "fullcalendar": "~2.7.3",
-    "fullcalendar-scheduler": "~1.3.2",
+    "fullcalendar": "^2.7.3",
+    "fullcalendar-scheduler": "^1.3.2",
     "moment": "~2.13.0"
   }
 }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,13 @@ module.exports = {
 
     app.import(app.bowerDirectory + '/fullcalendar/dist/fullcalendar.js');
     app.import(app.bowerDirectory + '/fullcalendar/dist/fullcalendar.css');
-    app.import(app.bowerDirectory + '/fullcalendar-scheduler/dist/scheduler.js');
-    app.import(app.bowerDirectory + '/fullcalendar-scheduler/dist/scheduler.css');
+
+    // Add scheduler to executable unless configured not to.
+    if (!app.options ||
+        !app.options.emberFullCalendar ||
+        app.options.emberFullCalendar.scheduler === undefined || app.options.emberFullCalendar.scheduler) {
+      app.import(app.bowerDirectory + '/fullcalendar-scheduler/dist/scheduler.js');
+      app.import(app.bowerDirectory + '/fullcalendar-scheduler/dist/scheduler.css');
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.4",
     "ember-getowner-polyfill": "1.0.1",
-    "ember-invoke-action": "1.2.0",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.1"
@@ -48,8 +47,9 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-htmlbars": "^1.0.3"
-  },
+    "ember-cli-htmlbars": "^1.0.3",
+    "ember-invoke-action": "^1.2.0"
+},
   "ember-addon": {
     "configPath": "tests/dummy/config"
   }


### PR DESCRIPTION
This PR:

- Allows opting-out of FullCalendar Scheduler.
- Specifies compatible semver versions of `fullcalendar` and `fullcalendar-scheduler` bower packages.
- Remove the automatic installation of `ember-cli-moment-shim` as it is not strictly needed.
- Updates the `README.md` to reflect the above changes.
- Adds a dependency for `ember-invoke-action`, which is required.