### PR TITLE
Removed es6 syntax for compatabilty with previous node versions

### DIFF
--- a/blueprints/ember-fullcalendar/index.js
+++ b/blueprints/ember-fullcalendar/index.js
@@ -2,8 +2,9 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('fullcalendar', '^2.7.3').then(() => {
-      return this.addBowerPackageToProject('fullcalendar-scheduler', '^1.3.2');
+    var self = this;
+    return this.addBowerPackageToProject('fullcalendar', '^2.7.3').then(function() {
+      return self.addBowerPackageToProject('fullcalendar-scheduler', '^1.3.2');
     });
   }
 };


### PR DESCRIPTION
Fix for install of component using ember-cli v2.5

Removed ES6 syntax