### PR TITLE
Support eventSources parameter

### DIFF
--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -238,7 +238,18 @@ export default Ember.Component.extend(InvokeActionMixin, {
      const fc = this.$();
      fc.fullCalendar('removeEvents');
      fc.fullCalendar('addEventSource', this.get('events'));
-     fc.fullCalendar('rerenderEvents');
+  }),
+
+  /**
+   * Observe the eventSources array for any changes and
+   * re-render if changes are detected
+   */
+  observeEventSources: observer('eventSources.[]', function () {
+     const fc = this.$();
+     fc.fullCalendar('removeEventSources');
+     this.get('eventSources').forEach(function(source,i,arr){
+       fc.fullCalendar('addEventSource', source);
+     });
   }),
 
   /**

--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -60,7 +60,7 @@ export default Ember.Component.extend(InvokeActionMixin, {
   fullCalendarOptions: [
     // general display
     'header', 'customButtons', 'buttonIcons', 'theme', 'themeButtonIcons', 'firstDay', 'isRTL', 'weekends', 'hiddenDays',
-    'fixedWeekCount', 'weekNumbers', 'weekNumberCalculation', 'businessHours', 'height', 'contentHeight', 'aspectRatio',
+    'fixedWeekCount', 'weekNumbers', 'weekNumberCalculation', 'weekNumbersWithinDays', 'businessHours', 'height', 'contentHeight', 'aspectRatio',
     'handleWindowResize', 'eventLimit',
 
     // timezone
@@ -77,11 +77,11 @@ export default Ember.Component.extend(InvokeActionMixin, {
     'nowIndicator',
 
     // text/time customization
-    'lang', 'timeFormat', 'columnFormat', 'titleFormat', 'buttonText', 'monthNames', 'monthNamesShort', 'dayNames',
+    'locale', 'timeFormat', 'columnFormat', 'titleFormat', 'buttonText', 'monthNames', 'monthNamesShort', 'dayNames',
     'dayNamesShort', 'weekNumberTitle', 'displayEventTime', 'displayEventEnd', 'eventLimitText', 'dayPopoverFormat',
 
     // selection
-    'selectable', 'selectHelper', 'unselectAuto', 'unselectCancel', 'selectOverlap', 'selectConstraint',
+    'selectable', 'selectHelper', 'unselectAuto', 'unselectCancel', 'selectOverlap', 'selectConstraint', 'selectAllow',
 
     // event data
     'events', 'eventSources', 'allDayDefault', 'startParam', 'endParam', 'timezoneParam', 'lazyFetching',
@@ -92,7 +92,7 @@ export default Ember.Component.extend(InvokeActionMixin, {
 
     // event dragging & resizing
     'editable', 'eventStartEditable', 'eventDurationEditable', 'dragRevertDuration', 'dragOpacity', 'dragScroll',
-    'eventOverlap', 'eventConstraint', 'longPressDelay',
+    'eventOverlap', 'eventConstraint', 'eventAllow', 'longPressDelay',
 
     // dropping external elements
     'droppable', 'dropAccept',


### PR DESCRIPTION
Reference :  #24
I removed the rerenders, which seems to be unnecessary when using **addEventSource**.
I thought we could use this one-liner :
`fc.fullCalendar( 'refetchEventSources', this.get('eventSources'));`
but it's not working in my setup...

Note: The merge I did includes the work from @beverlyguillermo , which should fix the IE compatibility issue, mentioned here : #23