### PR TITLE
Fullcalendar-scheduler v1.4.0 causes a dependency conflict

### DIFF
--- a/blueprints/ember-fullcalendar/index.js
+++ b/blueprints/ember-fullcalendar/index.js
@@ -4,7 +4,7 @@ module.exports = {
   afterInstall: function() {
     var self = this;
     return this.addBowerPackageToProject('fullcalendar', '^2.7.3').then(function() {
-      return self.addBowerPackageToProject('fullcalendar-scheduler', '^1.3.2');
+      return self.addBowerPackageToProject('fullcalendar-scheduler', '~1.3.2');
     });
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
     "fullcalendar": "^2.7.3",
-    "fullcalendar-scheduler": "^1.3.2",
+    "fullcalendar-scheduler": "~1.3.2",
     "moment": "~2.13.0"
   }
 }


### PR DESCRIPTION
From version 1.4.0, fullcalendar-scheduler specifies fullcalendar version >=3.0.0 as a dependency. This causes a conflict as this module states fullcalendar version ^2.7.3, which can't be satisfied by version 3.0.0.  This has been resolved by changing the dependency on fullcalendar-scheduler to ~1.3.3 instead of ^1.3.3, to stop version 1.4.0 being installed.