### PR TITLE
Added observer to event properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ Where possible, this addon takes advantage of DDAU (Data Down, Actions Up) to al
 
 - `date` _(replaces `defaultDate`)_ - allows you to change the date from outside of the component.
 
+### Event changes
+When an event can be changed from outside the calendar you need to convert the events to Ember.Objects.
+
+let events = Ember.A([
+Ember.Object.create({
+ title: 'Event 1',
+ start: '2016-05-05T07:08:08',
+ end: '2016-05-05T09:08:08'
+})]);
+
+events[0].set('title', 'My new event title');
+
 ### FullCalendar Callbacks
 All FullCalendar and FullCalendar Scheduler callbacks are supported and can be handled using Ember Actions. Here's a simple example:
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Where possible, this addon takes advantage of DDAU (Data Down, Actions Up) to al
 ### Event changes
 When an event can be changed from outside the calendar you need to convert the events to Ember.Objects.
 
+```javascript
 let events = Ember.A([
 Ember.Object.create({
  title: 'Event 1',
@@ -79,6 +80,7 @@ Ember.Object.create({
 })]);
 
 events[0].set('title', 'My new event title');
+```
 
 ### FullCalendar Callbacks
 All FullCalendar and FullCalendar Scheduler callbacks are supported and can be handled using Ember Actions. Here's a simple example:

--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -240,7 +240,7 @@ export default Ember.Component.extend(InvokeActionMixin, {
    * Observe the events array for any changes and
    * re-render if changes are detected
    */
-  observeEvents: observer('events.[]', function () {
+  observeEvents: observer('events.[]', 'events.@each.{start,end,title,color,allDay,url,className,editable,startEditable,durationEditable,resourceEditable,rendering,overlap,constraint,source,backgroundColor,borderColor,textColor}', function () {
      const fc = this.$();
      fc.fullCalendar('removeEvents');
      fc.fullCalendar('addEventSource', this.get('events'));


### PR DESCRIPTION
If the events are changed from outside the calendar the calendar wasn't updated. 
I added all available properties to the observer so the calendar is updated when a property changes.

Keep in mind that for this to work the events need to be Ember.Objects