### PR TITLE
Added observer to event properties 

### DIFF
--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -215,14 +215,21 @@ export default Ember.Component.extend(InvokeActionMixin, {
 
   /**
    * Observe the events array for any changes and
-   * re-render if changes are detected
+   * re-render if changes are detected. Debounce events as we are watching all the event properties which can generate a lot of re-renders.
    */
-  observeEvents: observer('events.[]', function () {
+  observeEvents: observer('events.[]', 'events.@each.{start,end,title,color,allDay,url,className,editable,startEditable,durationEditable,resourceEditable,rendering,overlap,constraint,source,backgroundColor,borderColor,textColor}', function () {
+     Ember.run.debounce(this, this.rerenderEvents, 50);
+  }),
+
+  /**
+   * removes and adds the events to the calendar
+   */
+  rerenderEvents: function () {
      const fc = this.$();
      fc.fullCalendar('removeEvents');
      fc.fullCalendar('addEventSource', this.get('events'));
-  }),
-
+  },
+  
   /**
    * Observe the eventSources array for any changes and
    * re-render if changes are detected

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,6 +1,10 @@
 /*jshint node:true*/
 'use strict';
 
-module.exports = function(/* environment, appConfig */) {
-  return { };
+module.exports = function (/* environment, appConfig */) {
+  return {
+    fullCalendar: {
+      eventsObserver: ['events.[]']
+    }
+  };
 };


### PR DESCRIPTION
If the events are changed from outside the calendar the calendar wasn't updated.
I added all available properties to the observer so the calendar is updated when a property changes.

Keep in mind that for this to work the events need to be Ember.Objects.

This PR includes Ember.run.debounce to prevent rerenders.
Based on PR: https://github.com/scoutforpets/ember-fullcalendar/pull/32
