### PR TITLE
Fix for ember-getowner-polyfill

### DIFF
--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -1,8 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/full-calendar';
 import { InvokeActionMixin } from 'ember-invoke-action';
-const { observer, computed } = Ember;
-import getOwner from 'ember-getowner-polyfill';
+const { observer, computed, getOwner } = Ember;
 
 
 // We need IE Support so using a polyfill for Object.assign


### PR DESCRIPTION
getOwner is now available directly through Ember.getOwner
Also the dependency still persist as it may be nedded in ember < ember@2.3