### PR TITLE
added action that only fires when view changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Where possible, this addon takes advantage of DDAU (Data Down, Actions Up) to al
 
 - `viewName` _(replaces `defaultView`)_ - allows you to change the view mode from outside of the component. For example, when using `header=false`, you can use your own buttons to modify the `viewName` property to change the view of the calendar.
 
+- `onViewChange` - pass an action to be notified when the view changes. This is different than the `viewRender` callback provided by FullCalendar as it is only triggered when the view changes and is not when any of the date navigation methods are called.
+
 - `date` _(replaces `defaultDate`)_ - allows you to change the date from outside of the component.
 
 ### FullCalendar Callbacks

--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -252,6 +252,11 @@ export default Ember.Component.extend(InvokeActionMixin, {
   viewNameDidChange: Ember.observer('viewName', function() {
     const viewName = this.get('viewName');
     this.$().fullCalendar('changeView', viewName);
+
+    // Call action if it exists
+    if (this.get('onViewChange')) {
+      this.get('onViewChange')(viewName);
+    }
   }),
 
   /**


### PR DESCRIPTION
This PR adds the `onViewChange` hook that is only fired when the view changes and returns the view name.