### PR TITLE
fix opting out of scheduler

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
       },
       'fullcalendar-scheduler': function() {
         return {
-          enabled: this.includeScheduler || true,
+          enabled: this.includeScheduler,
           srcDir: 'dist',
           import: ['scheduler.js', 'scheduler.css']
         }
@@ -29,9 +29,13 @@ module.exports = {
     // Add scheduler to executable unless configured not to.
     if (!app.options ||
         !app.options.emberFullCalendar ||
-        app.options.emberFullCalendar.scheduler === undefined || app.options.emberFullCalendar.scheduler) {
+        app.options.emberFullCalendar.scheduler === undefined || 
+        app.options.emberFullCalendar.scheduler === false) {
         this.includeScheduler = false;
+    } else {
+      this.includeScheduler = true;
     }
+
 
     this._super.included.apply(this, arguments);
   }


### PR DESCRIPTION
`enabled: this.includeScheduler || true` doesn't seem right to me,
won't this always return true even if `includeScheduler` is undefined,
null or false?

```
> a = undefined
undefined
> b = true
true
> a || b
true
> a = false
false
> a || b
true
> a = null
null
> a || b
true
```

It seems safer to explicitly set it to true.