### PR TITLE
Fix for actions invocation bug

### DIFF
--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -200,9 +200,7 @@ export default Ember.Component.extend(InvokeActionMixin, {
 
       // create an event handler that runs the function inside an event loop.
       actions[eventName] = (...args) => {
-        Ember.run.schedule('actions', this, () => {
-          this.invokeAction(eventName, ...args, this.$());
-        });
+        this.invokeAction(eventName, ...args, this.$());
       };
     });
 


### PR DESCRIPTION
I'm not sure what is the reason to use run loop for actions invocation.
I'm not very familiar with detailed concepts of run loop either.

But looks like invoking actions directly solves eventRender problem,.
Also, make sure you test nothing breaks with this. I have tested in my app and everything seems to work fine.

Fixes <https://github.com/scoutforpets/ember-fullcalendar/issues/48>