### PR TITLE
add 'includeLocales' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ export default Ember.Controller.extend({
 ## FullCalendar Scheduler
 
 ### Opting In
-By default, FullCalendar Scheduler is NOT imported. To include it, add the following to your application's `ember-cli-build.js`:
+By default, FullCalendar Scheduler is NOT imported. To include it, add the following to your application's `config/environment.js`:
 ```javascript
   var app = new EmberApp(defaults, {
     emberFullCalendar: {
@@ -125,6 +125,24 @@ By default, FullCalendar Scheduler is NOT imported. To include it, add the follo
     }
     // Other options here, as needed.
   });
+```
+
+## FullCalendar Locales
+
+By default, only English locale is available. If you need to use other locales, you have to include them in `config/environment.js` like this:
+```javascript
+  var app = new EmberApp(defaults, {
+    emberFullCalendar: {
+      includeLocales: ['fr', 'it']
+    }
+    // Other options here, as needed.
+  });
+```
+
+Then, you can set the fullcalendar language by using the `locale` option:
+
+```handlebars
+{{full-calendar events=events locale='fr'}}
 ```
 
 ## Fastboot Support

--- a/README.md
+++ b/README.md
@@ -119,34 +119,34 @@ export default Ember.Controller.extend({
 ### Opting In
 By default, FullCalendar Scheduler is NOT imported. To include it, add the following to your application's `config/environment.js`:
 ```javascript
-  var app = new EmberApp(defaults, {
-    emberFullCalendar: {
-      includeScheduler: true
-    }
-    // Other options here, as needed.
-  });
+var ENV = {
+  emberFullCalendar: {
+    includeScheduler: true
+  }
+  // Other options here, as needed.
+});
 ```
 
 ## FullCalendar Locales
 
 By default, only English locale is available. If you need to use other locales, you have to include them in `config/environment.js` like this:
 ```javascript
-  var app = new EmberApp(defaults, {
-    emberFullCalendar: {
+var ENV = {
+  emberFullCalendar: {
       includeLocales: ['fr', 'it']
-    }
-    // Other options here, as needed.
-  });
+  }
+  // Other options here, as needed.
+});
 ```
 
 Or, if you need ALL the locales, you can do the following:
 ```javascript
-  var app = new EmberApp(defaults, {
-    emberFullCalendar: {
+var ENV = {
+  emberFullCalendar: {
       includeLocales: 'all'
-    }
-    // Other options here, as needed.
-  });
+  }
+  // Other options here, as needed.
+});
 ```
 
 Then, you can set the fullcalendar language by using the `locale` option:

--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ By default, only English locale is available. If you need to use other locales, 
   });
 ```
 
+Or, if you need ALL the locales, you can do the following:
+```javascript
+  var app = new EmberApp(defaults, {
+    emberFullCalendar: {
+      includeLocales: 'all'
+    }
+    // Other options here, as needed.
+  });
+```
+
 Then, you can set the fullcalendar language by using the `locale` option:
 
 ```handlebars

--- a/index.js
+++ b/index.js
@@ -43,6 +43,8 @@ module.exports = {
       this.includeLocalesFiles = config.emberFullCalendar.includeLocales.map(function(localeCode) {
         return 'locale/' + localeCode + '.js';
       });
+    } else if(config.emberFullCalendar.includeLocales === "all") {
+      this.includeLocalesFiles = ['locale-all.js'];
     } else {
       this.includeLocalesFiles = [];
     }

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
         return {
           enabled: !process.env.EMBER_CLI_FASTBOOT,
           srcDir: 'dist',
-          import: ['fullcalendar.js', 'fullcalendar.css']
+          import: ['fullcalendar.js', 'fullcalendar.css'].concat(this.includeLocalesFiles)
         }
       },
       'fullcalendar-scheduler': function() {
@@ -37,6 +37,15 @@ module.exports = {
     }
 
     var config = target.project.config(target.env) || {};
+
+    // include locale files
+    if(config.emberFullCalendar && Array.isArray(config.emberFullCalendar.includeLocales)) {
+      this.includeLocalesFiles = config.emberFullCalendar.includeLocales.map(function(localeCode) {
+        return 'locale/' + localeCode + '.js';
+      });
+    } else {
+      this.includeLocalesFiles = [];
+    }
 
     // Add scheduler to executable unless configured not to.
     if (config.emberFullCalendar && config.emberFullCalendar.includeScheduler === true) {

--- a/index.js
+++ b/index.js
@@ -39,12 +39,16 @@ module.exports = {
     var config = target.project.config(target.env) || {};
 
     // include locale files
-    if(config.emberFullCalendar && Array.isArray(config.emberFullCalendar.includeLocales)) {
-      this.includeLocalesFiles = config.emberFullCalendar.includeLocales.map(function(localeCode) {
-        return 'locale/' + localeCode + '.js';
-      });
-    } else if(config.emberFullCalendar.includeLocales === "all") {
-      this.includeLocalesFiles = ['locale-all.js'];
+    if(config.emberFullCalendar && config.emberFullCalendar.includeLocales) {
+      if(Array.isArray(config.emberFullCalendar.includeLocales)) {
+        this.includeLocalesFiles = config.emberFullCalendar.includeLocales.map(function(localeCode) {
+          return 'locale/' + localeCode + '.js';
+        });
+      } else if(config.emberFullCalendar.includeLocales === "all") {
+        this.includeLocalesFiles = ['locale-all.js'];
+      } else {
+        this.includeLocalesFiles = [];
+      }
     } else {
       this.includeLocalesFiles = [];
     }


### PR DESCRIPTION
Hello,
This adds the 'includeLocales' environment option. 
You can selectively add the languages, by using an array:

```
includeLocales: ['fr', 'it']
```

or use the 'all' string, to include all the locales:
```
includeLocales: 'all'
```
This should supersede #42 