### PR TITLE
compatiblity with fastboot 1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 /* jshint node: true */
 'use strict';
+const fastbootTransform = require('fastboot-transform');
 
 module.exports = {
   name: 'ember-fullcalendar',
@@ -10,18 +11,17 @@ module.exports = {
 
   options: {
     nodeAssets: {
-      'fullcalendar': function() {
-        return {
-          enabled: !process.env.EMBER_CLI_FASTBOOT,
-          srcDir: 'dist',
-          import: ['fullcalendar.js', 'fullcalendar.css']
+      'fullcalendar': {
+        include: ['dist/fullcalendar.js', 'dist/fullcalendar.css'],
+        processTree(input) {
+          return fastbootTransform(input);
         }
       },
-      'fullcalendar-scheduler': function() {
-        return {
-          enabled: !process.env.EMBER_CLI_FASTBOOT && this.includeScheduler,
-          srcDir: 'dist',
-          import: ['scheduler.js', 'scheduler.css']
+      'fullcalendar-scheduler': {
+        enabled: this.includeScheduler,
+        include: ['dist/scheduler.js', 'dist/scheduler.css'],
+        processTree(input) {
+          return fastbootTransform(input);
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "ember-cli-node-assets": "0.2.2",
     "ember-invoke-action": "^1.4.0",
     "fullcalendar": "^3.3.0",
-    "fullcalendar-scheduler": "^1.6.0"
+    "fullcalendar-scheduler": "^1.6.0",
+    "fastboot-transform": "^0.1.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
See the upgrade guide, basically the environment variable has been removed.
https://gist.github.com/kratiahuja/d22de0fb1660cf0ef58f07a6bcbf1a1c#using-processenvember_cli_fastboot-to-run-import-in-fastboot-build