### PR TITLE
adds null check before adding event source

### DIFF
--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -219,9 +219,13 @@ export default Ember.Component.extend(InvokeActionMixin, {
    * re-render if changes are detected
    */
   observeEvents: observer('events.[]', function () {
-     const fc = this.$();
-     fc.fullCalendar('removeEvents');
-     fc.fullCalendar('addEventSource', this.get('events'));
+    const fc = this.$();
+    const events = this.get('events');
+
+    if (events) {
+      fc.fullCalendar('removeEvents');
+      fc.fullCalendar('addEventSource', this.get('events'));
+    }
   }),
 
   /**
@@ -230,9 +234,13 @@ export default Ember.Component.extend(InvokeActionMixin, {
    */
   observeEventSources: observer('eventSources.[]', function () {
      const fc = this.$();
+
      fc.fullCalendar('removeEventSources');
+
      this.get('eventSources').forEach(function(source){
-       fc.fullCalendar('addEventSource', source);
+       if (source) {
+         fc.fullCalendar('addEventSource', source);
+       }
      });
   }),
 
@@ -253,6 +261,7 @@ export default Ember.Component.extend(InvokeActionMixin, {
   viewNameDidChange: Ember.observer('viewName', function() {
     const viewName = this.get('viewName');
     const viewRange = this.get('viewRange');
+
     this.$().fullCalendar('changeView', viewName, viewRange);
 
     // Call action if it exists


### PR DESCRIPTION
There appears to be a lingering bug in FC versions 3.5.0+ that was causing an error when adding an event source. Previously, if the event source being added was `null`, FC just ignored it. With versions 3.5+, an error occurs. This was evidently fixed, but still running into. 

Tracking issue: https://github.com/fullcalendar/fullcalendar/issues/3845

Added a null check to only add event sources if they aren't null/undefined.