### PR TITLE
Fixed issue with resource auto-updating

### DIFF
--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -139,6 +139,13 @@ export default Ember.Component.extend(InvokeActionMixin, {
     // add the license key for the scheduler
     options.schedulerLicenseKey = this.get('schedulerLicenseKey');
 
+    // assign resources as a function if resources is an Array so refetchResources works
+    if (options.resources && options.resources instanceof Array) {
+      options.resources = (callback) => {
+        callback(this.get('resources'));
+      }
+    }
+
     this.$().fullCalendar(options);
   },
 


### PR DESCRIPTION
FullCalendar only supports refreshing resources via `refetchResource` if the resources option is a function or a JSON feed.

Relevant documentation:
https://fullcalendar.io/docs/resource_data/refetchResources/
https://fullcalendar.io/docs/resource_data/resources_json_feed/
https://fullcalendar.io/docs/resource_data/resources_function/

This PR wraps `options.resource` with a function per the FullCalendar documentation if it's passed to the component as an array, so that the `observeResources` observer works properly.