### PR TITLE
chore: bump ember-cli-moment-shim version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "ember-cli-babel": "^6.7.2",
     "ember-cli-htmlbars": "^2.0.1",
-    "ember-cli-moment-shim": "3.5.0",
+    "ember-cli-moment-shim": "3.8.0",
     "ember-cli-node-assets": "0.2.2",
     "ember-invoke-action": "^1.4.0",
     "fullcalendar": "^3.6.0",


### PR DESCRIPTION
My production builds were failing after upgrading to Ember 3.12 because of an `Unexpected token: eof (undefined)` error in `UglifyWriter` (see [Stack Overflow post](https://stackoverflow.com/questions/13634049/uglify-js-error-unexpected-token-eof-undefined)). I was able to fix it by adding a resolution for `ember-cli-moment-shim` to force version 3.8.0.